### PR TITLE
feat: accept new webhook format

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,12 +8,14 @@ datasource db {
 }
 
 model WebhookEvent {
-  id          Int      @id @default(autoincrement())
-  paymentOrderId  String  @db.VarChar(255)
-  clientId  String  @db.VarChar(255)
-  requestorId String  @db.VarChar(255)
-  payload     Json
-  receivedAt  DateTime @map("received_at")
+  id                     Int      @id @default(autoincrement())
+  externalPaymentOrderId String   @db.VarChar(255)
+  paymentOrderId         Int
+  clientId               String   @db.VarChar(255)
+  requestorId            String   @db.VarChar(255)
+  status                 String   @db.VarChar(255)
+  payload                Json
+  receivedAt             DateTime @map("received_at")
 
   @@map("webhook_events")
-} 
+}

--- a/src/repositories/webhook.repository.ts
+++ b/src/repositories/webhook.repository.ts
@@ -1,15 +1,15 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Prisma } from '@prisma/client';
 import { WebhookPayload } from '../types/webhook.types';
 import logger from '../utils/logger';
-import { stat } from 'fs';
 
 interface WebhookEventRecord {
   id: number;
-  paymentOrderId: string;
+  externalPaymentOrderId: string;
+  paymentOrderId: number;
   clientId: string;
   requestorId: string;
+  status: string;
   payload: string;
-  status: string
   receivedAt: Date;
 }
 
@@ -28,11 +28,12 @@ export class WebhookRepository {
     try {
       const webhookEvent = await this.prisma.webhookEvent.create({
         data: {
-          paymentOrderId: payload?.paymentOrderId,
-          clientId: payload?.clientId,
-          requestorId: payload?.requestorId,
-          status: payload?.status,
-          payload,
+          externalPaymentOrderId: payload.externalPaymentOrderId,
+          paymentOrderId: payload.paymentOrderId,
+          clientId: payload.clientId,
+          requestorId: payload.requestorId,
+          status: payload.status,
+          payload: payload as unknown as Prisma.JsonObject,
           receivedAt: new Date(),
         },
       });

--- a/src/types/webhook.types.ts
+++ b/src/types/webhook.types.ts
@@ -1,30 +1,46 @@
 import { z } from 'zod';
 
-export const WebhookPayloadSchema = z.object({
-  transaction: z.object({
+export const WebhookPayloadSchema = z
+  .object({
     id: z.string(),
-    type: z.string(),
-  }),
-  user: z.object({
-    id: z.string(),
-    email: z.string().email(),
-  }),
-  payment: z.object({
-    amount: z.number(),
-    currency: z.string(),
-    network: z.string(),
+    externalPaymentOrderId: z.string(),
+    paymentOrderId: z.number(),
+    requestorId: z.string(),
+    clientId: z.string(),
     status: z.string(),
-  }),
-  metadata: z.object({
-    ip: z.string(),
-    userAgent: z.string(),
-    timestamp: z.string(),
-  }),
-}).passthrough();
+    amount: z.string(),
+    currency: z.string(),
+    payway: z.string(),
+    destinationAddress: z.string(),
+    direction: z.string(),
+    estimatedFee: z.string(),
+    actualFee: z.string(),
+    ctime: z.number(),
+    ftime: z.number(),
+    txn: z.object({
+      txnId: z.string(),
+      txScanUrl: z.string(),
+      from: z.string(),
+      confirmations: z.number(),
+      status: z.string(),
+      direction: z.string(),
+      origin: z.string().nullable(),
+      value: z.string(),
+      txEstimatedFee: z.string(),
+      txFee: z.string(),
+      txcttime: z.number(),
+      txftime: z.number(),
+    }),
+    unpaid_amount: z.string(),
+    pay_is_internal: z.boolean(),
+    addressFrom: z.string(),
+    errorText: z.string().nullable(),
+  })
+  .passthrough();
 
 export type WebhookPayload = z.infer<typeof WebhookPayloadSchema>;
 
 export interface WebhookResponse {
   status: 'ok';
   receivedAt: string;
-} 
+}


### PR DESCRIPTION
## Summary
- support new payment webhook shape
- store external payment order and status via Prisma

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npx prisma generate`
- `npm run build`
- `npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68ac33bb336c8322ae0d1d22f68acbba